### PR TITLE
Fix duplicate title use

### DIFF
--- a/T002-Working-with-Variables/p016-confidence-check.mdx
+++ b/T002-Working-with-Variables/p016-confidence-check.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Confidence Check'
+title: 'How are you feeling?'
 slug: 'confidence-check'
 contentType: 'CheckForUnderstanding'
 ---

--- a/T002-Working-with-Variables/p016-confidence-check.mdx
+++ b/T002-Working-with-Variables/p016-confidence-check.mdx
@@ -1,5 +1,5 @@
 ---
 title: 'How are you feeling?'
-slug: 'confidence-check'
+slug: 'how-are-you-feeling'
 contentType: 'CheckForUnderstanding'
 ---


### PR DESCRIPTION
Can't use the same title / slug.

Also fixed in the CS 1.0 spreadsheet, so running the script again should be a-ok.

Open to other names!